### PR TITLE
Digging slightly deeper in the object hierarchy to set arrow color

### DIFF
--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -187,7 +187,7 @@ namespace OuterWildsRandomSpeedrun
             canvasMarker._mainTextField.color = OW_ORANGE_COLOR;
             canvasMarker._marker.material.color = OW_ORANGE_COLOR;
             canvasMarker._offScreenIndicator._textField.color = OW_ORANGE_COLOR;
-            canvasMarker._offScreenIndicator.GetComponentInChildren<MeshRenderer>().material.color = OW_ORANGE_COLOR;
+            canvasMarker._offScreenIndicator._arrow.GetComponentInChildren<MeshRenderer>().material.color = OW_ORANGE_COLOR;
             canvasMarker.SetVisibility(true);
         }
 


### PR DESCRIPTION
Just making use of a reference to go slightly deeper when searching for the MeshRenderer for the on-screen arrow goal indicator. Verified that it is working.