### PR TITLE
Moving constants to separate constants class, maintaining old menu selections, and improving gamepad support

### DIFF
--- a/OuterWildsRandomSpeedrun/Constants.cs
+++ b/OuterWildsRandomSpeedrun/Constants.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace OuterWildsRandomSpeedrun
+{
+  public class Constants
+  {
+    public static Color OW_ORANGE_COLOR = new Color(0.968f, 0.498f, 0.207f);
+    public static Color OW_SELECTED_COLOR = new Color(0.9882f, 0.8627f, 0.7686f);
+    public const string OW_MENU_FONT_NAME = "Adobe - SerifGothicStd-ExtraBold";
+    public const string SPEEDRUN_BUTTON_TEXT = "NOMAI GRAND PRIX";
+    public const string RESET_RUN_BUTTON_TEXT = "RESET SPAWN AND GOAL";
+  }
+}

--- a/OuterWildsRandomSpeedrun/Constants.cs
+++ b/OuterWildsRandomSpeedrun/Constants.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace OuterWildsRandomSpeedrun
 {
-  public class Constants
+  public struct Constants
   {
     public static Color OW_ORANGE_COLOR = new Color(0.968f, 0.498f, 0.207f);
     public static Color OW_SELECTED_COLOR = new Color(0.9882f, 0.8627f, 0.7686f);

--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -11,11 +11,7 @@ namespace OuterWildsRandomSpeedrun
 {
     public class OuterWildsRandomSpeedrun : ModBehaviour
     {
-        private const string SPEEDRUN_BUTTON_TEXT = "NOMAI GRAND PRIX";
         private const string RESUME_BUTTON_NAME = "Button-ResumeGame";
-        private const string OW_MENU_FONT_NAME = "Adobe - SerifGothicStd-ExtraBold";
-        private static Color OW_ORANGE_COLOR = new Color(0.968f, 0.498f, 0.207f);
-        private const string RESET_RUN_BUTTON_TEXT = "RESET SPAWN AND GOAL";
 
         private SpawnPoint _spawnPoint;
         private SpawnPoint _goalPoint;
@@ -33,12 +29,12 @@ namespace OuterWildsRandomSpeedrun
         private Material _marshmallowMaterial;
         private CanvasMarker _canvasMarker;
 
-    private SpawnPointSelectorManager _manager;
+        private SpawnPointSelectorManager _manager;
 
-    /// <summary>
-    /// Set to true when we have just entered the game (from the title screen) and have pending operations to complete, false otherwise.
-    /// </summary>
-    private bool _justEnteredGame = false;
+        /// <summary>
+        /// Set to true when we have just entered the game (from the title screen) and have pending operations to complete, false otherwise.
+        /// </summary>
+        private bool _justEnteredGame = false;
 
         /// <summary>
         /// Set to true when we have just began a time loop and have pending operations to complete, false otherwise.
@@ -51,8 +47,6 @@ namespace OuterWildsRandomSpeedrun
         private bool _isGameStarted;
 
         private System.Random _random;
-
-        private GameObject _spawnPointSelectorManager;
 
         private void Awake()
         {
@@ -88,7 +82,7 @@ namespace OuterWildsRandomSpeedrun
 
             ModHelper.Menus.MainMenu.OnInit += () =>
             {
-                _speedrunButton = ModHelper.Menus.MainMenu.ResumeExpeditionButton.Duplicate(SPEEDRUN_BUTTON_TEXT);
+                _speedrunButton = ModHelper.Menus.MainMenu.ResumeExpeditionButton.Duplicate(Constants.SPEEDRUN_BUTTON_TEXT);
                 _speedrunButton.OnClick += SpeedRunButton_OnClick;
 
                 _pingusButton = ModHelper.Menus.MainMenu.ResumeExpeditionButton.Duplicate("PINGUS MODE");
@@ -97,7 +91,7 @@ namespace OuterWildsRandomSpeedrun
 
             ModHelper.Menus.PauseMenu.OnInit += () =>
             {
-                _resetRunButton = ModHelper.Menus.PauseMenu.QuitButton.Duplicate(RESET_RUN_BUTTON_TEXT);
+                _resetRunButton = ModHelper.Menus.PauseMenu.QuitButton.Duplicate(Constants.RESET_RUN_BUTTON_TEXT);
                 _resetRunButton.OnClick += ResetRunButton_OnClick;
             };
         }
@@ -129,7 +123,7 @@ namespace OuterWildsRandomSpeedrun
             var elapsed = _endTime == DateTime.MinValue ? DateTime.Now - _startTime : _endTime - _startTime;
             
             var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
-            _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(OW_ORANGE_COLOR)}>{elapsedStr}</color>");
+            _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(Constants.OW_ORANGE_COLOR)}>{elapsedStr}</color>");
         }
 
         private void OnWakeUp()
@@ -158,7 +152,7 @@ namespace OuterWildsRandomSpeedrun
             var screenPromptList = screenPromptListObj.GetComponent<ScreenPromptList>();
 
             _timerPrompt = new ScreenPrompt("");
-            var font = GetFontByName(OW_MENU_FONT_NAME);
+            var font = GetFontByName(Constants.OW_MENU_FONT_NAME);
             var screenPromptElementObj = ScreenPromptElement.CreateNewScreenPrompt(_timerPrompt, 20, font, screenPromptListObj.transform, TextAnchor.LowerLeft);
             var screenPromptElement = screenPromptElementObj.GetComponent<ScreenPromptElement>();
             screenPromptList.AddScreenPrompt(screenPromptElement);
@@ -230,12 +224,8 @@ namespace OuterWildsRandomSpeedrun
 
         private void PingusModeButton_OnClick()
         {
-            if (_spawnPointSelectorManager == null)
-            {
-                _manager = SpawnPointSelectorManager.Instance;
-                _manager.ModHelper = ModHelper;
-            }
-
+            _manager = SpawnPointSelectorManager.Instance;
+            _manager.ModHelper = ModHelper;
             _manager.DisplayMenu();
         }
 
@@ -264,10 +254,10 @@ namespace OuterWildsRandomSpeedrun
             var markerManager = Locator.GetMarkerManager();
             _canvasMarker = markerManager.InstantiateNewMarker();
             markerManager.RegisterMarker(_canvasMarker, _goalPoint.transform, "GOAL");
-            _canvasMarker._mainTextField.color = OW_ORANGE_COLOR;
-            _canvasMarker._marker.material.color = OW_ORANGE_COLOR;
-            _canvasMarker._offScreenIndicator._textField.color = OW_ORANGE_COLOR;
-            _canvasMarker._offScreenIndicator._arrow.GetComponentInChildren<MeshRenderer>().material.color = OW_ORANGE_COLOR;
+            _canvasMarker._mainTextField.color = Constants.OW_ORANGE_COLOR;
+            _canvasMarker._marker.material.color = Constants.OW_ORANGE_COLOR;
+            _canvasMarker._offScreenIndicator._textField.color = Constants.OW_ORANGE_COLOR;
+            _canvasMarker._offScreenIndicator._arrow.GetComponentInChildren<MeshRenderer>().material.color = Constants.OW_ORANGE_COLOR;
             _canvasMarker.SetVisibility(true);
 
             var mapMarkerManager = Locator.GetMapController().GetMarkerManager();

--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -265,9 +265,9 @@ namespace OuterWildsRandomSpeedrun
             mapMarkerManager.RegisterMarker(mapMarker, _goalPoint.transform, UITextType.None);
             mapMarker.SetLabel("GOAL");
             var materialInstance = Instantiate(mapMarker._textField.material);
-            materialInstance.color = OW_ORANGE_COLOR;
+            materialInstance.color = Constants.OW_ORANGE_COLOR;
             mapMarker._textField.material = materialInstance;
-            mapMarker.SetColor(OW_ORANGE_COLOR);
+            mapMarker.SetColor(Constants.OW_ORANGE_COLOR);
             mapMarker.SetVisibility(true);
         }
 

--- a/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointMenu.cs
+++ b/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointMenu.cs
@@ -19,11 +19,5 @@ namespace OuterWildsRandomSpeedrun
       gameObject.GetComponent<SpawnPointList>().SetCollapsed(!shouldEnable);
       _menuActivationRoot.gameObject.SetActive(true);
     }
-
-    public override void OnCancelEvent(GameObject selectedObj, BaseEventData eventData)
-    {
-      base.OnCancelEvent(selectedObj, eventData);
-      SpawnPointSelectorManager.Instance.DisableMenu();
-    }
   }
 }

--- a/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointMenuOption.cs
+++ b/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointMenuOption.cs
@@ -3,22 +3,19 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using OWML.Common;
-using OWML.ModHelper;
 
 namespace OuterWildsRandomSpeedrun
 {
-  public class SpawnPointMenuOption : MenuOption
+  public class SpawnPointMenuOption : MenuOption, ISubmitHandler, ICancelHandler, IMoveHandler
   {
     public IModHelper ModHelper;
-    private static Color OW_ORANGE_COLOR = new Color(0.968f, 0.498f, 0.207f);
-    private static Color OW_SELECTED_COLOR = new Color(0.9882f, 0.8627f, 0.7686f);
     public override void OnSelect(BaseEventData eventData)
     {
 
       var listItem = this.gameObject.GetComponent<SpawnPointListItem>();
       listItem.LeftArrow.SetActive(true);
       listItem.RightArrow.SetActive(true);
-      listItem.Text.color = OW_SELECTED_COLOR;
+      listItem.Text.color = Constants.OW_SELECTED_COLOR;
   
       var list = listItem.transform.parent.parent.GetComponentInParent<SpawnPointList>();
       list.SetContentPosition(eventData.selectedObject);
@@ -41,7 +38,25 @@ namespace OuterWildsRandomSpeedrun
       var listItem = this.gameObject.GetComponent<SpawnPointListItem>();
       listItem.LeftArrow.SetActive(false);
       listItem.RightArrow.SetActive(false);
-      listItem.Text.color = OW_ORANGE_COLOR;
+      listItem.Text.color = Constants.OW_ORANGE_COLOR;
     }
+
+    public void OnSubmit(BaseEventData eventData)
+    {
+      SpawnPointSelectorManager.Instance.OnConfirmPressed(eventData);
+    }
+
+    public void OnCancel(BaseEventData eventData)
+    {
+      SpawnPointSelectorManager.Instance.OnCancelPressed(eventData);
+    }
+
+    public void OnMove(AxisEventData eventData)
+    {
+      if (eventData.moveDir == MoveDirection.Left || eventData.moveDir == MoveDirection.Right)
+      {
+        SpawnPointSelectorManager.Instance.OnLeftRightPressed(eventData);
+      }
+  }
   }
 }

--- a/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointSelectorManager.cs
+++ b/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointSelectorManager.cs
@@ -3,7 +3,7 @@ using SpawnPointSelector;
 using UnityEngine;
 using System;
 using System.Collections.Generic;
-using static UnityEngine.InputSystem.InputAction;
+using UnityEngine.EventSystems;
 
 namespace OuterWildsRandomSpeedrun
 {
@@ -22,8 +22,6 @@ namespace OuterWildsRandomSpeedrun
         return _instance;
       }
     }
-
-    private bool _menuDisplayed = false;
 
     /// <summary>
     /// The GameObject that hosts the SpawnPointSelectorManager singleton
@@ -62,19 +60,12 @@ namespace OuterWildsRandomSpeedrun
     
     public void DisplayMenu()
     {
-      _menuDisplayed = true;
-
       InitializeSelector();
       InitializeMenus();
 
+      _fromMenu.EnableMenu(true);
+      _toMenu.EnableMenu(false);
       _selector.gameObject.SetActive(true);
-      
-      var inputAction = (InputLibrary.menuLeft as InputCommands).Action as BasicInputAction;
-      inputAction.Action.performed += OnLeftRightPressed;
-      inputAction = (InputLibrary.menuRight as InputCommands).Action as BasicInputAction;
-      inputAction.Action.performed += OnLeftRightPressed;
-      inputAction = (InputLibrary.enter as InputCommands).Action as BasicInputAction;
-      inputAction.Action.performed += OnConfirmPressed;
     }
 
     private void InitializeMenus()
@@ -115,31 +106,14 @@ namespace OuterWildsRandomSpeedrun
 
       InitializeMenu(_fromMenu, _fromList);
       InitializeMenu(_toMenu, _toList);
-
-      _fromMenu.EnableMenu(true);
-      _toMenu.EnableMenu(false);
     }
 
     public void DisableMenu()
     {
-      _menuDisplayed = false;
       _fromMenu.EnableMenu(false);
       _toMenu.EnableMenu(false);
 
       _selector.gameObject.SetActive(false);
-
-      var inputAction = (InputLibrary.menuLeft as InputCommands).Action as BasicInputAction;
-      inputAction.Action.performed -= OnLeftRightPressed;
-      inputAction = (InputLibrary.menuRight as InputCommands).Action as BasicInputAction;
-      inputAction.Action.performed -= OnLeftRightPressed;
-      inputAction = (InputLibrary.enter as InputCommands).Action as BasicInputAction;
-      inputAction.Action.performed -= OnConfirmPressed;
-
-      Destroy(_fromMenu);
-      Destroy(_toMenu);
-
-      _fromMenu = null;
-      _toMenu = null;
     }
 
     private void InitializeSelector()
@@ -192,7 +166,7 @@ namespace OuterWildsRandomSpeedrun
         options.Add(menuOption);
     }
 
-    private void OnLeftRightPressed (CallbackContext context) {
+    public void OnLeftRightPressed (AxisEventData eventData) {
       var disableMenu = _fromMenu.IsMenuEnabled() ? _fromMenu : _toMenu;
       var enableMenu = disableMenu == _fromMenu ? _toMenu : _fromMenu;
 
@@ -200,11 +174,16 @@ namespace OuterWildsRandomSpeedrun
       enableMenu.EnableMenu(true);
     }
 
-    private void OnConfirmPressed(CallbackContext context)
+    public void OnConfirmPressed(BaseEventData eventData)
     {
       var from = _fromMenu._lastSelected.GetComponent<SpawnPointListItem>().Text.text;
       var to = _toMenu._lastSelected.GetComponent<SpawnPointListItem>().Text.text;
       ModHelper.Console.WriteLine($"Oh my, we've been confirmed with {from} and {to}");
+      DisableMenu();
+    }
+
+    public void OnCancelPressed(BaseEventData eventData)
+    {
       DisableMenu();
     }
   }


### PR DESCRIPTION
This change does the following:
- Moves a number of constants that could hypothetically/actually be shared across classes into its their own class.
- Changes the way submit/cancel/move events happen to make it simpler and to include gamepad support
- Stops deleting menus when the menu is exited so that the same options as before are selected when you leave &* re-enter the menu.

Testing:
- Verified that you can leave & exit the menu multiple times
- Verified that same menu options as before are selected if you leave & re-enter the spawn menu
- Verified that L/R/U/D, Cancel, and Submit work with both keyboard & gamepad (including analog sticks & dpad)