### PR TITLE
Fixing player death upon spawn (hopefully)

### DIFF
--- a/OuterWildsRandomSpeedrun/SpeedrunHarmonyPatches.cs
+++ b/OuterWildsRandomSpeedrun/SpeedrunHarmonyPatches.cs
@@ -52,4 +52,15 @@ public class SpeedrunHarmonyPatches {
   {
     SpeedrunState.IsGameStarted = true;
   }
+
+  [HarmonyPrefix]
+  [HarmonyPatch(typeof(PlayerSpawner), nameof(PlayerSpawner.OnStartOfTimeLoop))]
+  public static void PlayerSpawner_OnStartOfTimeLoop_Prefix()
+  {
+    if (SpeedrunState.ModEnabled) {
+      // Do not call SpawnPlayer() here
+      return;
+    }
+  }
+
 }


### PR DESCRIPTION
This change does the following:
- Patches the PlayerSpawner to not run its usual spawning behavior when the mod is enabled
- Makes the mod use PlayerSpawner's spawning behavior when a loop starts, but using our chosen spawn point

Testing:
- Spawned at White Hole Station ~20 times, spawning in the same way each time. I exited the game after each attempt. This would sometimes kill me before my changes.
- Tested many random spawn points with the random respawn option in the pause menu successfully.
- Verified that the normal game still works as expected.