### PR TITLE
Fixing run counter not updating on new runs, making run counter start at the right time, and not spawning marshmallow on complete runs

### DIFF
--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -29,7 +29,7 @@ namespace OuterWildsRandomSpeedrun
         private System.Random _random;
 
         private SpawnPointPool _spawnPointPool;
-
+    
         private void Awake()
         {
             // You won't be able to access OWML's mod helper in Awake.
@@ -78,23 +78,25 @@ namespace OuterWildsRandomSpeedrun
                 return;
             }
 
-            if (SpeedrunState.JustEnteredGame)
-            {
-                SpeedrunState.JustEnteredGame = false;
-                SpeedrunState.StartTime = DateTime.Now;
-            }
-
             if (SpeedrunState.JustStartedTimeLoop)
             {
                 SpeedrunState.JustStartedTimeLoop = false;
                 HandleNewLoopSetup();
                 InitMapMarker();
                 SpawnGoal(_goalPoint.transform);
+
+                if (SpeedrunState.JustEnteredGame)
+                {
+                    SpeedrunState.JustEnteredGame = false;
+                    SpeedrunState.StartTime = DateTime.Now;
+                    SpeedrunState.EndTime = DateTime.MinValue;
+                }
             }
 
             var elapsed = SpeedrunState.EndTime == DateTime.MinValue ? DateTime.Now - SpeedrunState.StartTime : SpeedrunState.EndTime - SpeedrunState.StartTime;
             var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
             _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(Constants.OW_ORANGE_COLOR)}>{elapsedStr}</color>");
+            
         }
 
         private void OnStartOfTimeLoop(int loopCount)
@@ -119,7 +121,7 @@ namespace OuterWildsRandomSpeedrun
             var screenPromptElementObj = ScreenPromptElement.CreateNewScreenPrompt(_timerPrompt, 20, font, screenPromptListObj.transform, TextAnchor.LowerLeft);
             var screenPromptElement = screenPromptElementObj.GetComponent<ScreenPromptElement>();
             screenPromptList.AddScreenPrompt(screenPromptElement);
-        }
+    }
 
         private void HandleBasicWarp(PlayerSpawner spawner, SpawnPoint[] spawnPoints)
         {
@@ -176,6 +178,7 @@ namespace OuterWildsRandomSpeedrun
         {
             SpeedrunState.SpawnPoint = GetRandomSpawnConfig();
             SpeedrunState.GoalPoint = GetRandomSpawnConfig();
+
             SpeedrunState.JustEnteredGame = true;
             Locator.GetDeathManager().KillPlayer(DeathType.Meditation);
             ModHelper.Menus.PauseMenu.Close();
@@ -233,6 +236,11 @@ namespace OuterWildsRandomSpeedrun
 
         private void SpawnGoal(Transform parent)
         {
+            if (SpeedrunState.EndTime != DateTime.MinValue)
+            {
+                return;
+            }
+
             var go = new GameObject("GoalPoint");
             var collider = go.AddComponent<SphereCollider>();
             collider.isTrigger = true;

--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -121,7 +121,7 @@ namespace OuterWildsRandomSpeedrun
             var screenPromptElementObj = ScreenPromptElement.CreateNewScreenPrompt(_timerPrompt, 20, font, screenPromptListObj.transform, TextAnchor.LowerLeft);
             var screenPromptElement = screenPromptElementObj.GetComponent<ScreenPromptElement>();
             screenPromptList.AddScreenPrompt(screenPromptElement);
-    }
+        }
 
         private void HandleBasicWarp(PlayerSpawner spawner, SpawnPoint[] spawnPoints)
         {

--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -66,8 +66,11 @@ namespace OuterWildsRandomSpeedrun
 
             ModHelper.Menus.PauseMenu.OnInit += () =>
             {
-                _resetRunButton = ModHelper.Menus.PauseMenu.QuitButton.Duplicate(Constants.RESET_RUN_BUTTON_TEXT);
-                _resetRunButton.OnClick += ResetRunButton_OnClick;
+                if (SpeedrunState.ModEnabled)
+                {
+                    _resetRunButton = ModHelper.Menus.PauseMenu.QuitButton.Duplicate(Constants.RESET_RUN_BUTTON_TEXT);
+                    _resetRunButton.OnClick += ResetRunButton_OnClick;
+                }
             };
         }
 


### PR DESCRIPTION
This change does the following:
- Modifies the time at which we start the clock, so it only happens when we've started a new run AND a new time loop has started. This fixes when the counter is started when the pause menu randomizer button is used.
- Resets the end time when we start a new run so the timer appears
- Does not spawn the marshmallow if you meditate after completing a run

There is one problem remaining after this change, which is an edge case I'm not sure if we care about: After completing a run, if you meditate, the timer does not reappear. This is more complicated to fix.

Testing:
- Verified counter starts when we begin a run from the title screen
- Verified counter restarts if you go back to the title screen and start a new run
- Verified the counter doesn't stop if you meditate
- Verified that the counter restarts if you randomize the spawn & goal from the pause menu, and that the counter doesn't start until the next time loop begins
- Verified that the counter stops when you eat the marshmallow
- Verified that the counter restarts if you complete a run, then go back to the title screen and start a new run, or use the randomize button in the pause menu