### PR TITLE
Making spawn menu maintain previous selections between games

### DIFF
--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -128,6 +128,11 @@ namespace OuterWildsRandomSpeedrun
 
         private void HandleBasicWarp(PlayerSpawner spawner, SpawnPoint[] spawnPoints)
         {
+            if (!SpeedrunState.SpawnPoint.HasValue || !SpeedrunState.GoalPoint.HasValue)
+            {
+                throw new InvalidOperationException("Spawn point or goal point was null when attempting to warp");
+            }
+
             _spawnPoint = GetSpawnPointByName(spawnPoints, SpeedrunState.SpawnPoint?.internalId);
             _goalPoint = GetSpawnPointByName(spawnPoints, SpeedrunState.GoalPoint?.internalId);
             ModHelper.Console.WriteLine($"Warp to {_spawnPoint.ToString()}!", MessageType.Success);
@@ -150,6 +155,10 @@ namespace OuterWildsRandomSpeedrun
                 ship.SetActive(false);
             }
 
+            if (!SpeedrunState.SpawnPoint.HasValue)
+            {
+                ModHelper.Console.WriteLine("Spawn point was null when attempting to determine if village music should be deactivated", MessageType.Warning);
+            }
             if (!(bool) SpeedrunState.SpawnPoint?.isThVillage) {
                 var villageMusicController = FindObjectOfType<VillageMusicVolume>();
                 villageMusicController.Deactivate();
@@ -203,6 +212,11 @@ namespace OuterWildsRandomSpeedrun
 
         private void InitMapMarker()
         {
+            if (!SpeedrunState.SpawnPoint.HasValue || !SpeedrunState.GoalPoint.HasValue)
+            {
+                ModHelper.Console.WriteLine("Goal point was null when attempting to create goal marker", MessageType.Warning);
+            }
+
             var labelText = $"GOAL: {SpeedrunState.GoalPoint?.displayName.ToUpper()}";
             var markerManager = Locator.GetMarkerManager();
             _canvasMarker = markerManager.InstantiateNewMarker();

--- a/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
+++ b/OuterWildsRandomSpeedrun/OuterWildsRandomSpeedrun.cs
@@ -128,8 +128,8 @@ namespace OuterWildsRandomSpeedrun
 
         private void HandleBasicWarp(PlayerSpawner spawner, SpawnPoint[] spawnPoints)
         {
-            _spawnPoint = GetSpawnPointByName(spawnPoints, SpeedrunState.SpawnPoint.internalId);
-            _goalPoint = GetSpawnPointByName(spawnPoints, SpeedrunState.GoalPoint.internalId);
+            _spawnPoint = GetSpawnPointByName(spawnPoints, SpeedrunState.SpawnPoint?.internalId);
+            _goalPoint = GetSpawnPointByName(spawnPoints, SpeedrunState.GoalPoint?.internalId);
             ModHelper.Console.WriteLine($"Warp to {_spawnPoint.ToString()}!", MessageType.Success);
             spawner.SetInitialSpawnPoint(_spawnPoint);
             Locator.GetPlayerBody().gameObject.AddComponent<MatchInitialMotion>();
@@ -150,7 +150,7 @@ namespace OuterWildsRandomSpeedrun
                 ship.SetActive(false);
             }
 
-            if (!SpeedrunState.SpawnPoint.isThVillage) {
+            if (!(bool) SpeedrunState.SpawnPoint?.isThVillage) {
                 var villageMusicController = FindObjectOfType<VillageMusicVolume>();
                 villageMusicController.Deactivate();
             }
@@ -203,7 +203,7 @@ namespace OuterWildsRandomSpeedrun
 
         private void InitMapMarker()
         {
-            var labelText = $"GOAL: {SpeedrunState.GoalPoint.displayName.ToUpper()}";
+            var labelText = $"GOAL: {SpeedrunState.GoalPoint?.displayName.ToUpper()}";
             var markerManager = Locator.GetMarkerManager();
             _canvasMarker = markerManager.InstantiateNewMarker();
             markerManager.RegisterMarker(_canvasMarker, _goalPoint.transform, labelText);

--- a/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointSelectorManager.cs
+++ b/OuterWildsRandomSpeedrun/SpawnPointMenu/SpawnPointSelectorManager.cs
@@ -157,12 +157,6 @@ namespace OuterWildsRandomSpeedrun
       unselectedList.SetContentPosition(unselectedMenuSelectable.gameObject);
     }
 
-    private Selectable GetRandomSelectable(SpawnPointMenu menu)
-    {
-      var randomIndex = _random.Next(_fromMenu._menuOptions.Length);
-      return menu._menuOptions[randomIndex]._selectable;
-    }
-
     public void OnLeftRightPressed (AxisEventData eventData)
     {
       SwapMenus();
@@ -307,9 +301,22 @@ namespace OuterWildsRandomSpeedrun
     }
 
     private void SetInitialSelection(SpawnPointMenu menu, SpawnPointList list){
-      var selectable = GetRandomSelectable(menu);
+      var currentSpawn = menu == _fromMenu ? SpeedrunState.SpawnPoint : SpeedrunState.GoalPoint;
+      var selectable = currentSpawn.HasValue ? FindSelectableForSpawn(menu, currentSpawn) : GetRandomSelectable(menu);
       list.SetContentPosition(selectable.gameObject);
       menu.SetSelectOnActivate(selectable);
+    }
+
+    private Selectable GetRandomSelectable(SpawnPointMenu menu)
+    {
+      var randomIndex = _random.Next(_fromMenu._menuOptions.Length);
+      return menu._menuOptions[randomIndex]._selectable;
+    }
+
+    private Selectable FindSelectableForSpawn(SpawnPointMenu menu, SpawnPointConfig? currentSpawn)
+    {
+      var foundMenuOption = Array.Find<MenuOption>(menu._menuOptions, menuOption => ((SpawnPointMenuOption) menuOption).SpawnPoint.internalId == currentSpawn?.internalId);
+      return foundMenuOption._selectable;
     }
 
     private void addMenuItem(SpawnPointConfig spawnConfig, SpawnPointList list, List<MenuOption> options)

--- a/OuterWildsRandomSpeedrun/SpeedrunState.cs
+++ b/OuterWildsRandomSpeedrun/SpeedrunState.cs
@@ -6,19 +6,19 @@ namespace OuterWildsRandomSpeedrun
   {
     private static SpeedrunState Instance = new SpeedrunState();
 
-    public static SpawnPointConfig SpawnPoint
+    public static SpawnPointConfig? SpawnPoint
     {
       get => Instance._spawnPoint;
       set => Instance._spawnPoint = value;
     }
-    private SpawnPointConfig _spawnPoint;
+    private SpawnPointConfig? _spawnPoint;
 
-    public static SpawnPointConfig GoalPoint
+    public static SpawnPointConfig? GoalPoint
     {
       get => Instance._goalPoint;
       set => Instance._goalPoint = value;
     }
-    private SpawnPointConfig _goalPoint;
+    private SpawnPointConfig? _goalPoint;
 
     public static DateTime StartTime
     {


### PR DESCRIPTION
This change does the following:
- Makes the spawn menu select the previously-selected items between games, instead of randomizing them. The options are only randomized the first time you open the menu now (or if you use one of the randomize buttons).

Testing:
- Verified initial menu selections are randomized
- Verified going back to the title screen & opening the spawn menu after existing the game mode selects the previously-selected items