### PR TITLE
Excluding Stranger spawn points when the player does not have the DLC

### DIFF
--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -43,11 +43,12 @@ namespace NomaiGrandPrix
         {
             // Starting here, you'll have access to OWML's mod helper.
             ModHelper.Console.WriteLine($"Mod {nameof(NomaiGrandPrix)} is loaded!", MessageType.Success);
+            var hasDlc = EntitlementsManager.IsDlcOwned() == EntitlementsManager.AsyncOwnershipStatus.Owned;
 
             // Initialize spawn points from TSV
             var parentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var pathToTsv = Path.Combine(parentDir, "SpawnPoints.tsv");
-            _spawnPointPool = SpawnPointPool.FromTsv(pathToTsv);
+            _spawnPointPool = SpawnPointPool.FromTsv(pathToTsv, spawnPoint => (spawnPoint.area & (Area.Stranger | Area.DreamZone)) == 0 || hasDlc);
             ModHelper.Console.WriteLine($"Loaded {_spawnPointPool.SpawnPointConfigs.Count} spawn points", MessageType.Debug);
 
             _random = new System.Random((int)DateTime.Now.Ticks);

--- a/NomaiGrandPrix/SpawnPointPool.cs
+++ b/NomaiGrandPrix/SpawnPointPool.cs
@@ -42,7 +42,7 @@ namespace NomaiGrandPrix
 
         private List<SpawnPointConfig> _spawnPointConfigs;
 
-        public SpawnPointConfig RandomSpawnPointConfig(Random random, Func<SpawnPointConfig, bool> filter)
+        public SpawnPointConfig RandomSpawnPointConfig(Random random, Func<SpawnPointConfig, bool> filter = null)
         {
             var filtered = filter != null ? _spawnPointConfigs.Where(filter).ToList() : _spawnPointConfigs;
             var randomIndex = random.Next(filtered.Count);
@@ -54,8 +54,11 @@ namespace NomaiGrandPrix
             this._spawnPointConfigs = configs;
         }
 
-        public static SpawnPointPool FromTsv(string pathToTsv, Func<SpawnPointConfig, bool> filter)
+        public static SpawnPointPool FromTsv(string pathToTsv, Func<SpawnPointConfig, bool> filter = null)
         {
+            if (filter == null) {
+                filter = spawnConfig => true;
+            }
             var configs = ParseTsv(pathToTsv)
                 .Select(line => BuildSpawnPointConfig(line))
                 .Where(filter)

--- a/NomaiGrandPrix/SpawnPointPool.cs
+++ b/NomaiGrandPrix/SpawnPointPool.cs
@@ -7,17 +7,17 @@ namespace NomaiGrandPrix
 {
     public enum Area
     {
-        None,
-        SunStation,
-        AshTwin,
-        EmberTwin,
-        TimberHearth,
-        BrittleHollow,
-        GiantsDeep,
-        DarkBramble,
-        Interloper,
-        Stranger,
-        DreamZone,
+        None = 1,
+        SunStation = 1 << 1,
+        AshTwin = 1 << 2,
+        EmberTwin = 1 << 3,
+        TimberHearth = 1 << 4,
+        BrittleHollow = 1 << 5,
+        GiantsDeep = 1 << 6,
+        DarkBramble = 1 << 7,
+        Interloper = 1 << 8,
+        Stranger = 1 << 9,
+        DreamZone = 1 << 10,
     }
     public struct SpawnPointConfig
     {
@@ -42,7 +42,7 @@ namespace NomaiGrandPrix
 
         private List<SpawnPointConfig> _spawnPointConfigs;
 
-        public SpawnPointConfig RandomSpawnPointConfig(Random random, Func<SpawnPointConfig, bool> filter = null)
+        public SpawnPointConfig RandomSpawnPointConfig(Random random, Func<SpawnPointConfig, bool> filter)
         {
             var filtered = filter != null ? _spawnPointConfigs.Where(filter).ToList() : _spawnPointConfigs;
             var randomIndex = random.Next(filtered.Count);
@@ -54,9 +54,12 @@ namespace NomaiGrandPrix
             this._spawnPointConfigs = configs;
         }
 
-        public static SpawnPointPool FromTsv(string pathToTsv)
+        public static SpawnPointPool FromTsv(string pathToTsv, Func<SpawnPointConfig, bool> filter)
         {
-            var configs = ParseTsv(pathToTsv).Select(line => BuildSpawnPointConfig(line)).ToList();
+            var configs = ParseTsv(pathToTsv)
+                .Select(line => BuildSpawnPointConfig(line))
+                .Where(filter)
+                .ToList();
             return new SpawnPointPool(configs);
         }
 


### PR DESCRIPTION
This change does the following:
- Excludes Stranger/DreamZone spawn points when the player does not have the DLC
- Removes the default "null" parameter used for the Where clause when retrieving a random spawn point, because it would cause an NRE if used

Testing:
- Verified that Stranger/DreamZone spawns appear when you have the DLC
- When the check is changed to NotOwned instead of Owned, verified that the Stranger/DreamZone spawns do not appear.