### PR TITLE
Sunken module no longer traps you as a spawn point

### DIFF
--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -87,6 +87,8 @@ namespace NomaiGrandPrix
                 HandleNewLoopSetup();
                 InitMapMarker();
                 SpawnGoal(_goalPoint.transform);
+                var spawnActions = SpawnActionFactory.GetActionsForSpawn(SpeedrunState.SpawnPoint?.internalId);
+                spawnActions.Do(action => action.Invoke());
 
                 if (SpeedrunState.JustEnteredGame)
                 {

--- a/NomaiGrandPrix/SpawnActionFactory.cs
+++ b/NomaiGrandPrix/SpawnActionFactory.cs
@@ -1,39 +1,37 @@
 using System;
+using System.Collections.Generic;
 
 namespace NomaiGrandPrix
 {
-  public class SpawnActionFactory
-  {
-    private static SpawnActionFactory Instance = new SpawnActionFactory();
-
-
-    private SpawnActionFactory()
+    public class SpawnActionFactory
     {
-      // Private constructor
-    }
+        private static SpawnActionFactory Instance = new SpawnActionFactory();
+        private static Dictionary<string, Action[]> actionsMap = new Dictionary<string, Action[]>
+        {
+            {"Spawn_Module_Sunken", new Action[] { OpenSunkenModuleAirlock }}
+        };
+        
+        private SpawnActionFactory()
+        {
+            // Private constructor
+        }
 
-    public static Action[] GetActionsForSpawn(string spawnId)
-    {
-      if (spawnId == null)
-      {
-        throw new InvalidOperationException("Spawn ID for getting actions cannot be null");
-      }
-      
-      switch (spawnId)
-      {
-        case "Spawn_Module_Sunken":
-          return new Action[] { OpenSunkenModuleAirlock };
-        default:
-          return new Action[0];
-      }
+        public static Action[] GetActionsForSpawn(string spawnId)
+        {
+            if (spawnId == null)
+            {
+                throw new InvalidOperationException("Spawn ID for getting actions cannot be null");
+            }
+            
+            return actionsMap.GetValueOrDefault(spawnId, new Action[0]);
+        }
 
+        private static void OpenSunkenModuleAirlock()
+        {
+            var giantsDeep = Locator._giantsDeep;
+            var airlock = giantsDeep.GetComponentInChildren<NomaiAirlock>();
+            var position = airlock._closeSwitches[0].transform.position;
+            airlock._listInterfaceOrb[0].SetOrbPosition(position);
+        }
     }
-    private static void OpenSunkenModuleAirlock()
-    {
-      var giantsDeep = Locator._giantsDeep;
-      var airlock = giantsDeep.GetComponentInChildren<NomaiAirlock>();
-      var position = airlock._closeSwitches[0].transform.position;
-      airlock._listInterfaceOrb[0].SetOrbPosition(position);
-    }
-  }
 }

--- a/NomaiGrandPrix/SpawnActionFactory.cs
+++ b/NomaiGrandPrix/SpawnActionFactory.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace NomaiGrandPrix
+{
+  public class SpawnActionFactory
+  {
+    private static SpawnActionFactory Instance = new SpawnActionFactory();
+
+
+    private SpawnActionFactory()
+    {
+      // Private constructor
+    }
+
+    public static Action[] GetActionsForSpawn(string spawnId)
+    {
+      if (spawnId == null)
+      {
+        throw new InvalidOperationException("Spawn ID for getting actions cannot be null");
+      }
+      
+      switch (spawnId)
+      {
+        case "Spawn_Module_Sunken":
+          return new Action[] { OpenSunkenModuleAirlock };
+        default:
+          return new Action[0];
+      }
+
+    }
+    private static void OpenSunkenModuleAirlock()
+    {
+      var giantsDeep = Locator._giantsDeep;
+      var airlock = giantsDeep.GetComponentInChildren<NomaiAirlock>();
+      var position = airlock._closeSwitches[0].transform.position;
+      airlock._listInterfaceOrb[0].SetOrbPosition(position);
+    }
+  }
+}

--- a/NomaiGrandPrix/SpawnPoints.tsv
+++ b/NomaiGrandPrix/SpawnPoints.tsv
@@ -85,7 +85,7 @@ Spawn_LakebedCave	Lakebed Cave	EmberTwin	FALSE	TRUE	TRUE	FALSE
 SPAWN_MigrationPath	Migration Path		FALSE	TRUE	TRUE	FALSE	
 Spawn_Module_Broken	Orbital Probe Cannon Broken Module	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 Spawn_Module_Intact	Orbital Probe Cannon Intact Module	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
-Spawn_Module_Sunken	Orbital Probe Cannon Sunken Module	GiantsDeep	FALSE	FALSE	TRUE	FALSE	Trapped if used as spawn
+Spawn_Module_Sunken	Orbital Probe Cannon Sunken Module	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 Spawn_NorthPole	North Pole		FALSE	FALSE	FALSE	FALSE	Spawns you in the middle of space
 SPAWN_NorthPole	North Pole		FALSE	TRUE	TRUE	FALSE	
 SPAWN_NorthPoleSecretEntrance	North Pole Secret Entrance		FALSE	TRUE	TRUE	FALSE	


### PR DESCRIPTION
This change does the following:
- Introduces a factory for spawn-specific actions that should take place when a time loop starts
- Adds an action to open the nomai airlock for the OPC sunken module
- Re-enables the sunken module as a usable spawn point