### PR TITLE
Opening airlocks when OPC intact module spawn is selected so player is not trapped

### DIFF
--- a/NomaiGrandPrix/SpawnActionFactory.cs
+++ b/NomaiGrandPrix/SpawnActionFactory.cs
@@ -8,7 +8,8 @@ namespace NomaiGrandPrix
         private static SpawnActionFactory Instance = new SpawnActionFactory();
         private static Dictionary<string, Action[]> actionsMap = new Dictionary<string, Action[]>
         {
-            { "Spawn_Module_Sunken", new Action[] { OpenSunkenModuleAirlock } }
+            { "Spawn_Module_Sunken", new Action[] { OpenSunkenModuleAirlock } },
+            { "Spawn_Module_Intact", new Action[] { OpenProbeCannonAirlocks } }
         };
 
         private SpawnActionFactory()
@@ -28,10 +29,22 @@ namespace NomaiGrandPrix
 
         private static void OpenSunkenModuleAirlock()
         {
-            var giantsDeep = Locator._giantsDeep;
-            var airlock = giantsDeep.GetComponentInChildren<NomaiAirlock>();
-            var position = airlock._closeSwitches[0].transform.position;
-            airlock._listInterfaceOrb[0].SetOrbPosition(position);
+            OpenAirlocks(Locator._giantsDeep);
+        }
+
+        private static void OpenProbeCannonAirlocks()
+        {
+            OpenAirlocks(Locator._orbitalProbeCannon);
+        }
+
+        private static void OpenAirlocks(AstroObject astroObject)
+        {
+            var airlocks = astroObject.GetComponentsInChildren<NomaiAirlock>();
+            foreach (NomaiAirlock airlock in airlocks)
+            {
+                var position = airlock._closeSwitches[0].transform.position;
+                airlock._listInterfaceOrb[0].SetOrbPosition(position);
+            }
         }
     }
 }


### PR DESCRIPTION
This change does the following:
- Automatically opens the 2 airlocks in the Orbital Probe Cannon when the "Orbital Probe Cannon Intact Module" spawn is selected, so the player is not trapped.

Testing:
- Verified that both the Sunken and Intact module spawns work as expected.