### PR TITLE
Adding Quantum Moon to areas

### DIFF
--- a/NomaiGrandPrix/SpawnPointMenu/SpawnPointSelectorManager.cs
+++ b/NomaiGrandPrix/SpawnPointMenu/SpawnPointSelectorManager.cs
@@ -97,6 +97,7 @@ namespace NomaiGrandPrix
             { Area.DarkBramble, SpawnPointPlanet.DarkBramble },
             { Area.Interloper, SpawnPointPlanet.Interloper },
             { Area.WhiteHole, SpawnPointPlanet.WhiteHole },
+            { Area.QuantumMoon, SpawnPointPlanet.QuantumMoon },
             { Area.Stranger, SpawnPointPlanet.Stranger },
             { Area.DreamZone, SpawnPointPlanet.DreamZone }
         };

--- a/NomaiGrandPrix/SpawnPointPool.cs
+++ b/NomaiGrandPrix/SpawnPointPool.cs
@@ -17,8 +17,9 @@ namespace NomaiGrandPrix
         DarkBramble = 1 << 7,
         Interloper = 1 << 8,
         WhiteHole = 1 << 9,
-        Stranger = 1 << 10,
-        DreamZone = 1 << 11,
+        QuantumMoon = 1 << 10,
+        Stranger = 1 << 11,
+        DreamZone = 1 << 12,
     }
 
     public struct SpawnPointConfig


### PR DESCRIPTION
This change does the following:
- Adds QuantumMoon to the Area enum and adds a mapping of this new area to its related SpawnPointPlanet enum value

Testing:
- Verified that the spawn menu still loads correctly