### PR TITLE
Making clicking on a spawn menu switch to that menu

### DIFF
--- a/NomaiGrandPrix/SpawnPointMenu/SpawnPointMenuOption.cs
+++ b/NomaiGrandPrix/SpawnPointMenu/SpawnPointMenuOption.cs
@@ -2,14 +2,11 @@ using SpawnPointSelector;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-using OWML.Common;
 
 namespace NomaiGrandPrix
 {
-    public class SpawnPointMenuOption : MenuOption, ISubmitHandler, ICancelHandler, IMoveHandler
+    public class SpawnPointMenuOption : MenuOption, ISubmitHandler, ICancelHandler, IMoveHandler, IPointerClickHandler
     {
-        public IModHelper ModHelper;
-
         public SpawnPointConfig SpawnPoint { get; set; }
 
         private Coroutine _selectionCoroutine;
@@ -32,17 +29,6 @@ namespace NomaiGrandPrix
 
             var menu = listItem.transform.parent.parent.GetComponentInParent<SpawnPointMenu>();
             menu.SetSelectOnActivate(GetComponent<Selectable>());
-        }
-
-        private void SetListPosition(SpawnPointList list, GameObject selectedObj)
-        {
-            var listTransform = list.GetComponent<RectTransform>();
-            var listSpacing = list.ContentTransform.GetComponent<VerticalLayoutGroup>().spacing;
-            var selectedObjHeight = selectedObj.GetComponent<RectTransform>().sizeDelta.y;
-            var selectedObjIndex = selectedObj.transform.GetSiblingIndex();
-            var listContentTransform = list.ContentTransform.GetComponent<RectTransform>();
-            var newPosition = selectedObjHeight / 2 + selectedObjIndex * (selectedObjHeight + listSpacing);
-            listContentTransform.anchoredPosition = new Vector2(listContentTransform.anchoredPosition.x, newPosition);
         }
 
         public override void OnDeselect(BaseEventData eventData)
@@ -69,6 +55,11 @@ namespace NomaiGrandPrix
             {
                 SpawnPointSelectorManager.Instance.OnLeftRightPressed(eventData);
             }
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            SpawnPointSelectorManager.Instance.OnItemClicked(eventData, this);
         }
     }
 }

--- a/NomaiGrandPrix/SpawnPointMenu/SpawnPointSelectorManager.cs
+++ b/NomaiGrandPrix/SpawnPointMenu/SpawnPointSelectorManager.cs
@@ -86,7 +86,8 @@ namespace NomaiGrandPrix
 
         private System.Random _random = new System.Random((int)DateTime.Now.Ticks);
 
-        private Dictionary<Area, SpawnPointPlanet> _areaToPlanetDict = new Dictionary<Area, SpawnPointPlanet>() {
+        private Dictionary<Area, SpawnPointPlanet> _areaToPlanetDict = new Dictionary<Area, SpawnPointPlanet>()
+        {
             { Area.None, SpawnPointPlanet.None },
             { Area.SunStation, SpawnPointPlanet.SunStation },
             { Area.AshTwin, SpawnPointPlanet.AshTwin },
@@ -208,9 +209,25 @@ namespace NomaiGrandPrix
             DisableMenu();
         }
 
+        public void OnItemClicked(PointerEventData eventData, SpawnPointMenuOption option)
+        {
+            var eventMenu = GetMenuForMenuOption(option);
+
+            if (!eventMenu.IsMenuEnabled())
+            {
+                SwapMenus();
+            }
+        }
+
         private void OnUpdateInputDevice()
         {
             UpdateTooltipIcons();
+        }
+
+        private SpawnPointMenu GetMenuForMenuOption(SpawnPointMenuOption option)
+        {
+            var menu = option.transform.parent.parent.parent == _fromList.transform ? _fromMenu : _toMenu;
+            return menu;
         }
 
         private void InitializeMenus()
@@ -363,7 +380,6 @@ namespace NomaiGrandPrix
             var menuOption = listItem.gameObject.AddComponent<SpawnPointMenuOption>();
             menuOption.SpawnPoint = spawnConfig;
             menuOption.Initialize();
-            menuOption.ModHelper = ModHelper;
             options.Add(menuOption);
         }
     }


### PR DESCRIPTION
This change does the following:
- When clicking on a spawn menu, we switch to that menu instead of being in a weird broken state

Testing:
- Verified that clicking the menu that is not open opens it
- Verified that clicking the menu that is already open does nothing
- Verified that this behavior works for both the "from" and "to" menus