### PR TITLE
Prefixing spawns with numbers

### DIFF
--- a/NomaiGrandPrix/SpawnPointMenu/SpawnPointSelectorManager.cs
+++ b/NomaiGrandPrix/SpawnPointMenu/SpawnPointSelectorManager.cs
@@ -374,7 +374,7 @@ namespace NomaiGrandPrix
 
         private void AddMenuItem(SpawnPointConfig spawnConfig, SpawnPointList list, List<MenuOption> options)
         {
-            var listItem = list.AddItem(spawnConfig.displayName, _areaToPlanetDict[spawnConfig.area]);
+            var listItem = list.AddItem($"{options.Count + 1}. {spawnConfig.displayName}", _areaToPlanetDict[spawnConfig.area]);
             listItem.gameObject.AddComponent<SelectableAudioPlayer>();
 
             var menuOption = listItem.gameObject.AddComponent<SpawnPointMenuOption>();

--- a/NomaiGrandPrix/SpawnPoints.tsv
+++ b/NomaiGrandPrix/SpawnPoints.tsv
@@ -40,10 +40,10 @@ SPAWN_EscapePod	Escape Pod 1 	BrittleHollow	FALSE	TRUE	TRUE	FALSE
 SPAWN_GravityCannon	Gravity Cannon	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_City	Hanging City Bridge	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_MigrationPath	Migration Path Trailhead	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
-SPAWN_OldCamp	Old Camp	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
-SPAWN_OldSettlement	Old Settlement	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_NorthPoleSecretEntrance	North Pole Secret Entrance	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_NorthPole	North Pole Surface	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
+SPAWN_OldCamp	Old Camp	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
+SPAWN_OldSettlement	Old Settlement	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_Observatory	Southern Observatory	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_Observatory_Below	Southern Observatory (Below)	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_SouthPole	Southern Observatory (Below)	BrittleHollow	FALSE	FALSE	FALSE	FALSE	

--- a/NomaiGrandPrix/SpawnPoints.tsv
+++ b/NomaiGrandPrix/SpawnPoints.tsv
@@ -40,8 +40,8 @@ SPAWN_EscapePod	Escape Pod 1 	BrittleHollow	FALSE	TRUE	TRUE	FALSE
 SPAWN_GravityCannon	Gravity Cannon	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_City	Hanging City Bridge	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_MigrationPath	Migration Path Trailhead	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
-SPAWN_OldCamp	Nomai Camp (Above Ground)	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
-SPAWN_OldSettlement	Nomai Settlement (Below Ground)	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
+SPAWN_OldCamp	Old Camp	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
+SPAWN_OldSettlement	Old Settlement	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_NorthPoleSecretEntrance	North Pole Secret Entrance	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_NorthPole	North Pole Surface	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_Observatory	Southern Observatory	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
@@ -99,7 +99,7 @@ Spawn_IP_Zone_3_Bridge	Hidden Gorge Bridge	Stranger	FALSE	FALSE	TRUE	FALSE
 Spawn_IP_Zone_3_BrokenBridge	Hidden Gorge Broken Bridge	Stranger	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_3_CodeDoor	Hidden Gorge Code Door	Stranger	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_3_DreamFire	Hidden Gorge Dream Fire	Stranger	FALSE	FALSE	TRUE	FALSE	
-Spawn_IP_Zone_3_DreamLabOverlook	Hidden Gorge Laboratory Overlook	Stranger	FALSE	FALSE	TRUE	FALSE	
+Spawn_IP_Zone_3_DreamLabOverlook	Hidden Gorge Lab Overlook	Stranger	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_3_Raft	Hidden Gorge Raft	Stranger	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_3_SecretEntrance	Hidden Gorge Secret Entrance	Stranger	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_3_Temple	Hidden Gorge Temple	Stranger	FALSE	FALSE	TRUE	FALSE	


### PR DESCRIPTION
This change prefixes all of the spawns in the menu with their index (+1). It also shortens a few names so they fit.

Testing:
- Verified that the numbers appear as expected and that no names in the list are too long.