### PR TITLE
Fixed Several Spawn point issues noticed during playtest

### DIFF
--- a/NomaiGrandPrix/SpawnPoints.tsv
+++ b/NomaiGrandPrix/SpawnPoints.tsv
@@ -2,12 +2,12 @@ Full Name	Display Name	Area	Dream Zone	Enable Spawn	Enable Goal	TH Village	Note
 Spawn	Sun Station Inside	SunStation	FALSE	TRUE	TRUE	FALSE	
 ShipSpawn	Sun Station Outside	SunStation	FALSE	FALSE	FALSE	TRUE	
 Spawn_TimeLoopDevice	Ash Twin Project	AshTwin	FALSE	FALSE	TRUE	FALSE	Trapped if used as spawn
-Spawn_SunTower	Warp Tower (Sun Station)	AshTwin	FALSE	TRUE	TRUE	FALSE	
-Spawn_TowerTwin	Warp Tower (Twins)	AshTwin	FALSE	TRUE	TRUE	FALSE	
+Spawn_SunTower	Ash Twin Surface	AshTwin	FALSE	TRUE	TRUE	FALSE	
+Spawn_TowerTwin	Ash Twin Surface	AshTwin	FALSE	FALSE	FALSE	FALSE	
 Spawn_FossilSite	Anglerfish Fossil	EmberTwin	FALSE	TRUE	TRUE	FALSE	
 Spawn_FossilOverlook	Anglerfish Fossil Overlook	EmberTwin	FALSE	TRUE	TRUE	FALSE	
 Spawn_ChertsCamp	Chert's Camp	EmberTwin	FALSE	TRUE	TRUE	FALSE	
-Spawn_EscapePod_Exterior	Escape Pod 2 Exterior	EmberTwin	FALSE	TRUE	TRUE	FALSE	
+Spawn_EscapePod_Exterior	Escape Pod 2	EmberTwin	FALSE	TRUE	TRUE	FALSE	
 Spawn_EscapePod_Interior	Escape Pod 2 Interior	EmberTwin	FALSE	FALSE	FALSE	FALSE	
 Spawn_GravityCannon	Gravity Cannon	EmberTwin	FALSE	TRUE	TRUE	FALSE	
 Spawn_TLE_Below	High Energy Lab Below	EmberTwin	FALSE	TRUE	TRUE	FALSE	
@@ -30,11 +30,12 @@ Spawn_TH_NomaiMines	Nomai Mines	TimberHearth	FALSE	TRUE	TRUE	FALSE
 Spawn_TH_Observatory	Observatory	TimberHearth	FALSE	TRUE	TRUE	TRUE	
 Spawn_TH_RadioTower	Radio Tower	TimberHearth	FALSE	TRUE	TRUE	FALSE	
 ShipSpawn_TH	Ship Timber Hearth	TimberHearth	FALSE	FALSE	FALSE	TRUE	Spawn kills you from fall damage if you do not compensate
-Spawn_Ship	Timber Hearth Orbit	TimberHearth	FALSE	TRUE	TRUE	TRUE	Kills you the first time (probably being killed by the ship before it is deactivated)
+Spawn_Ship	Timber Hearth Orbit	TimberHearth	FALSE	FALSE	FALSE	TRUE	Kills you the first time (probably being killed by the ship before it is deactivated)
 Spawn_TH_ZeroGCave	Zero G Cave	TimberHearth	FALSE	TRUE	TRUE	FALSE	
 SPAWN_UpdownWarp	Black Hole Forge District	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
+SPAWN_Teleporter	Black Hole Forge District	BrittleHollow	FALSE	FALSE	FALSE	FALSE	
 SPAWN_BlackholeForge	Blackhole Forge	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
-SPAWN_SHIP	Brittle Hollow Orbit	BrittleHollow	FALSE	TRUE	TRUE	TRUE	Severely hurts you from fall damage
+SPAWN_SHIP	Brittle Hollow Orbit	BrittleHollow	FALSE	FALSE	FALSE	TRUE	Severely hurts you from fall damage
 SPAWN_Crossroad	Crossroads	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_EscapePod	Escape Pod 1 	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_GravityCannon	Gravity Cannon	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
@@ -52,13 +53,12 @@ SPAWN_QuantumTower_Top	Tower Grove	BrittleHollow	FALSE	TRUE	TRUE	FALSE
 SPAWN_QuantumTower_Bottom	Tower of Quantum Knowledge	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 SPAWN_QuantumTower_Inside	Tower of Quantum Knowledge Inside	BrittleHollow	FALSE	FALSE	FALSE	FALSE	
 SPAWN_QuantumTower_Path	Tower of Quantum Knowledge Path	BrittleHollow	FALSE	FALSE	FALSE	FALSE	
-SPAWN_Teleporter	Warp Receiver (Surface)	BrittleHollow	FALSE	TRUE	TRUE	FALSE	
 Spawn_BrambleIsland	Bramble Island	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 Spawn_ConstructionYard	Construction Yard	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 Spawn_Core	Core	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 Spawn_GabbroIsland	Gabbro's Island	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 ShipSpawn_GD	Giant's Deep Orbit	GiantsDeep	FALSE	FALSE	FALSE	FALSE	
-Spawn_DeepSpace	Giant's Deep Orbit	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
+Spawn_DeepSpace	Giant's Deep Orbit	GiantsDeep	FALSE	FALSE	FALSE	FALSE	
 ShipSpawn_JellyDomain	Jelly Domain	GiantsDeep	FALSE	FALSE	FALSE	FALSE	Duplicate
 Spawn_JellyDomain	Jelly Domain	GiantsDeep	FALSE	TRUE	TRUE	FALSE	Northern Half of GD
 Spawn_OPC	Probe Cannon	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
@@ -69,7 +69,7 @@ Spawn_StatueIsland_Beach	Statue Island Beach	GiantsDeep	FALSE	TRUE	TRUE	FALSE
 Spawn_StatueIsland_Inside	Statue Island Inside	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 Spawn_StatueIsland_Top	Statue Island Top	GiantsDeep	FALSE	TRUE	TRUE	FALSE	
 Spawn_QuantumIsland_Bottom	Tower of Quantum Trials	GiantsDeep	FALSE	TRUE	TRUE	FALSE	Outside by elevator
-Spawn_QuantumIsland_PuzzleRoom4	Tower of Quantum Trials Bottom	GiantsDeep	FALSE	TRUE	TRUE	FALSE	End of last solved puzzle
+Spawn_QuantumIsland_PuzzleRoom4	Tower of Quantum Trials Bottom	GiantsDeep	FALSE	TRUE	FALSE	FALSE	End of last solved puzzle (impossible to reach)
 Spawn_QuantumIsland_Top	Tower of Quantum Trials Top	GiantsDeep	FALSE	TRUE	TRUE	FALSE	Before entering first puzzle
 SpawnPoint_Ship_DB	Dark Bramble Orbit	DarkBramble	FALSE	FALSE	FALSE	FALSE	
 SpawnPoint_DB	Dark Bramble Orbit	DarkBramble	FALSE	TRUE	TRUE	FALSE	
@@ -87,8 +87,11 @@ ShipSpawnPoint_WhiteHole(1)	White Hole Orbit	WhiteHole	FALSE	FALSE	FALSE	FALSE	C
 Spawn_CO	Interloper	Interloper	FALSE	TRUE	TRUE	FALSE	
 Spawn_CO_Core	Interloper Core	Interloper	FALSE	TRUE	TRUE	FALSE	
 Spawn_CO_Interior	Interloper Interior	Interloper	FALSE	TRUE	TRUE	FALSE	
-ShipSpawn_CO	Interloper Orbit	Interloper	FALSE	TRUE	TRUE	FALSE	
-ShipSpawn_QM	Quantum Moon Orbit		FALSE	FALSE	FALSE	FALSE	Spawns you in the middle of space
+ShipSpawn_CO	Interloper Orbit	Interloper	FALSE	FALSE	FALSE	FALSE	
+Spawn_NorthPole	Quantum Moon North Pole	QuantumMoon	FALSE	FALSE	TRUE	FALSE	
+ShipSpawn_QM	Quantum Moon Orbit	QuantumMoon	FALSE	FALSE	FALSE	FALSE	Spawns you in the middle of space
+Spawn_Orbit	Quantum Moon Orbit	QuantumMoon	FALSE	FALSE	FALSE	FALSE	
+Spawn_Surface	Quantum Moon South Pole	QuantumMoon	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_2	Cinder Isles	Stranger	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_2_CoveBottom	Cinder Isles Cove Bottom	Stranger	FALSE	FALSE	TRUE	FALSE	
 Spawn_IP_Zone_2_CoveTop	Cinder Isles Cove Top	Stranger	FALSE	FALSE	TRUE	FALSE	
@@ -141,13 +144,10 @@ Spawn_DreamZone_3_SecretGallery	DreamZone 3 Secret Gallery	DreamZone	TRUE	FALSE	
 Spawn_DreamZone_4_Bridge	DreamZone 4 Bridge	DreamZone	TRUE	FALSE	FALSE	FALSE	
 Spawn_DreamZone_4_Dock	DreamZone 4 Dock	DreamZone	TRUE	FALSE	FALSE	FALSE	
 Spawn_DreamZone_4_Elevator	DreamZone 4 Elevator	DreamZone	TRUE	FALSE	FALSE	FALSE	
-Spawn_SecretLibrary_1	Secret Library 1	DreamZone	FALSE	FALSE	FALSE	FALSE	Stranger
-Spawn_SecretLibrary_2	Secret Library 2	DreamZone	FALSE	FALSE	FALSE	FALSE	Stranger
-Spawn_SecretLibrary_3	Secret Library 3	DreamZone	FALSE	FALSE	FALSE	FALSE	Stranger
-Spawn_Underground_CodeTotems	Underground Code Totems	DreamZone	TRUE	FALSE	FALSE	FALSE	Stranger (Is this dreamzone? It has to be right?)
-Spawn_Underground_OOB	Underground OOB	DreamZone	TRUE	FALSE	FALSE	FALSE	Stranger
-Spawn_Underground_PrisonCell	Underground Prison Cell	DreamZone	TRUE	FALSE	FALSE	FALSE	Stranger
-Spawn_Underground_PrisonCell_Lower	Underground Prison Cell Lower	DreamZone	TRUE	FALSE	FALSE	FALSE	Stranger
-Spawn_NorthPole	North Pole		FALSE	FALSE	FALSE	FALSE	Spawns you in the middle of space
-Spawn_Orbit	Orbit		FALSE	FALSE	FALSE	FALSE	Spawns you in the middle of space
-Spawn_Surface	Surface		FALSE	FALSE	FALSE	FALSE	Spawns you in the middle of space
+Spawn_SecretLibrary_1	Secret Library 1	DreamZone	FALSE	FALSE	FALSE	FALSE	
+Spawn_SecretLibrary_2	Secret Library 2	DreamZone	FALSE	FALSE	FALSE	FALSE	
+Spawn_SecretLibrary_3	Secret Library 3	DreamZone	FALSE	FALSE	FALSE	FALSE	
+Spawn_Underground_CodeTotems	Underground Code Totems	DreamZone	TRUE	FALSE	FALSE	FALSE	
+Spawn_Underground_OOB	Underground OOB	DreamZone	TRUE	FALSE	FALSE	FALSE	
+Spawn_Underground_PrisonCell	Underground Prison Cell	DreamZone	TRUE	FALSE	FALSE	FALSE	
+Spawn_Underground_PrisonCell_Lower	Underground Prison Cell Lower	DreamZone	TRUE	FALSE	FALSE	FALSE	


### PR DESCRIPTION
Fixed:
Ash Twin Surface Dupe
Escape Pod 2 Rename
BHF Dupe
TQT impossible goal
Reenabled and labelled QM points as goals
Disable Deadly Timber Hearth Spawn
Alphabetize to accommodate changes
