### PR TITLE
Enabling Ash Twin Project as a spawn point

### DIFF
--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -15,7 +15,7 @@ namespace NomaiGrandPrix
     {
         private const string RESUME_BUTTON_NAME = "Button-ResumeGame";
 
-        public SpawnPoint _spawnPoint;
+        private SpawnPoint _spawnPoint;
         private SpawnPoint _goalPoint;
         private IModButton _speedrunButton;
         private IModButton _resetRunButton;

--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -15,7 +15,7 @@ namespace NomaiGrandPrix
     {
         private const string RESUME_BUTTON_NAME = "Button-ResumeGame";
 
-        private SpawnPoint _spawnPoint;
+        public SpawnPoint _spawnPoint;
         private SpawnPoint _goalPoint;
         private IModButton _speedrunButton;
         private IModButton _resetRunButton;

--- a/NomaiGrandPrix/SpawnActionFactory.cs
+++ b/NomaiGrandPrix/SpawnActionFactory.cs
@@ -1,16 +1,20 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace NomaiGrandPrix
 {
     public class SpawnActionFactory
     {
         private static SpawnActionFactory Instance = new SpawnActionFactory();
+        private const int SAND_CRUSH_THRESHOLD_SECS = 415;
+
         private static Dictionary<string, Action[]> actionsMap = new Dictionary<string, Action[]>
         {
             { "Spawn_Module_Sunken", new Action[] { OpenSunkenModuleAirlock } },
             { "Spawn_Module_Intact", new Action[] { OpenProbeCannonAirlocks } },
             { "Spawn_TH_ZeroGCave", new Action[] { LowerZeroGElevator } },
+            { "Spawn_TimeLoopDevice", new Action[] { CreateAshTwinCampfire, ActivateAshTwinWarpReceiver }},
         };
 
         private SpawnActionFactory()
@@ -56,6 +60,44 @@ namespace NomaiGrandPrix
             elevator._goingToTheEnd = true;
             elevator._targetLocalPos = elevator._endLocalPos;
             elevator.StartLift();
+        }
+
+        private static void CreateAshTwinCampfire()
+        {
+            var timeLoopRing = GameObject.Find("TimeLoopRing_Body/Interactibles_TimeLoopRing_Hidden");
+            var campfirePrefab = Locator._hourglassTwinA._rootSector.transform.Find("Sector_NorthHemisphere/Sector_NorthSurface/Sector_Lakebed/Interactables_Lakebed/Lakebed_VisibleFrom_Far/Prefab_HEA_Campfire");
+            var campfire = GameObject.Instantiate(campfirePrefab.gameObject, timeLoopRing.transform);
+            
+            campfire.transform.localPosition = new Vector3(18, 0.18f, -21);
+            campfire.transform.Rotate(new Vector3(95, 0, 38), Space.Self);
+
+            var interactReceiver = campfire.GetComponentInChildren<InteractReceiver>();
+            interactReceiver.Start();
+            interactReceiver.EnableInteraction();
+
+            var attachPoint = campfire.GetComponentInChildren<PlayerAttachPoint>();
+            attachPoint.Start();
+            attachPoint.enabled = true;
+        }
+
+        private static void ActivateAshTwinWarpReceiver()
+        {
+            var returnPlatformGO = Locator._hourglassTwinB._rootSector.transform.Find("Sector_Tower_HGT/Interactables_Tower_HGT/Interactables_Tower_TT/Prefab_NOM_WarpTransmitter (1)");
+            var returnPlatform = returnPlatformGO.GetComponent<NomaiWarpTransmitter>();
+            returnPlatform.OnReceiveWarpedBody += KillPlayerIfEnteringSand;
+            
+            var warpReceiver = GameObject.Find("TimeLoopRing_Body/Interactibles_TimeLoopRing_Hidden/Prefab_NOM_WarpReceiver").GetComponent<NomaiWarpReceiver>();
+            warpReceiver._exitPlatformTime = Time.time;
+            warpReceiver._waitToActivateReturnWarp = true;
+            warpReceiver._returnPlatform = returnPlatform;
+            
+        }
+
+        private static void KillPlayerIfEnteringSand(OWRigidbody warpedBody, NomaiWarpPlatform startPlaform, NomaiWarpPlatform targetPlatform) {
+            if (Time.timeSinceLevelLoad <= SAND_CRUSH_THRESHOLD_SECS)
+            {
+                Locator._deathManager.KillPlayer(DeathType.Crushed);
+            }
         }
     }
 }

--- a/NomaiGrandPrix/SpawnActionFactory.cs
+++ b/NomaiGrandPrix/SpawnActionFactory.cs
@@ -14,7 +14,7 @@ namespace NomaiGrandPrix
             { "Spawn_Module_Sunken", new Action[] { OpenSunkenModuleAirlock } },
             { "Spawn_Module_Intact", new Action[] { OpenProbeCannonAirlocks } },
             { "Spawn_TH_ZeroGCave", new Action[] { LowerZeroGElevator } },
-            { "Spawn_TimeLoopDevice", new Action[] { CreateAshTwinCampfire, ActivateAshTwinWarpReceiver }},
+            { "Spawn_TimeLoopDevice", new Action[] { CreateAshTwinCampfire, ActivateAshTwinWarpReceiver } },
         };
 
         private SpawnActionFactory()
@@ -65,9 +65,11 @@ namespace NomaiGrandPrix
         private static void CreateAshTwinCampfire()
         {
             var timeLoopRing = GameObject.Find("TimeLoopRing_Body/Interactibles_TimeLoopRing_Hidden");
-            var campfirePrefab = Locator._hourglassTwinA._rootSector.transform.Find("Sector_NorthHemisphere/Sector_NorthSurface/Sector_Lakebed/Interactables_Lakebed/Lakebed_VisibleFrom_Far/Prefab_HEA_Campfire");
+            var campfirePrefab = Locator._hourglassTwinA._rootSector.transform.Find(
+                "Sector_NorthHemisphere/Sector_NorthSurface/Sector_Lakebed/Interactables_Lakebed/Lakebed_VisibleFrom_Far/Prefab_HEA_Campfire"
+            );
             var campfire = GameObject.Instantiate(campfirePrefab.gameObject, timeLoopRing.transform);
-            
+
             campfire.transform.localPosition = new Vector3(18, 0.18f, -21);
             campfire.transform.Rotate(new Vector3(95, 0, 38), Space.Self);
 
@@ -82,18 +84,26 @@ namespace NomaiGrandPrix
 
         private static void ActivateAshTwinWarpReceiver()
         {
-            var returnPlatformGO = Locator._hourglassTwinB._rootSector.transform.Find("Sector_Tower_HGT/Interactables_Tower_HGT/Interactables_Tower_TT/Prefab_NOM_WarpTransmitter (1)");
+            var returnPlatformGO = Locator._hourglassTwinB._rootSector.transform.Find(
+                "Sector_Tower_HGT/Interactables_Tower_HGT/Interactables_Tower_TT/Prefab_NOM_WarpTransmitter (1)"
+            );
             var returnPlatform = returnPlatformGO.GetComponent<NomaiWarpTransmitter>();
             returnPlatform.OnReceiveWarpedBody += KillPlayerIfEnteringSand;
-            
-            var warpReceiver = GameObject.Find("TimeLoopRing_Body/Interactibles_TimeLoopRing_Hidden/Prefab_NOM_WarpReceiver").GetComponent<NomaiWarpReceiver>();
+
+            var warpReceiver = GameObject
+                .Find("TimeLoopRing_Body/Interactibles_TimeLoopRing_Hidden/Prefab_NOM_WarpReceiver")
+                .GetComponent<NomaiWarpReceiver>();
             warpReceiver._exitPlatformTime = Time.time;
             warpReceiver._waitToActivateReturnWarp = true;
             warpReceiver._returnPlatform = returnPlatform;
-            
         }
 
-        private static void KillPlayerIfEnteringSand(OWRigidbody warpedBody, NomaiWarpPlatform startPlaform, NomaiWarpPlatform targetPlatform) {
+        private static void KillPlayerIfEnteringSand(
+            OWRigidbody warpedBody,
+            NomaiWarpPlatform startPlaform,
+            NomaiWarpPlatform targetPlatform
+        )
+        {
             if (Time.timeSinceLevelLoad <= SAND_CRUSH_THRESHOLD_SECS)
             {
                 Locator._deathManager.KillPlayer(DeathType.Crushed);

--- a/NomaiGrandPrix/SpawnActionFactory.cs
+++ b/NomaiGrandPrix/SpawnActionFactory.cs
@@ -8,6 +8,8 @@ namespace NomaiGrandPrix
     {
         private static SpawnActionFactory Instance = new SpawnActionFactory();
         private const int SAND_CRUSH_THRESHOLD_SECS = 415;
+        private static Vector3 CAMPFIRE_SPAWN_POSITION = new Vector3(18f, 0.18f, -21f);
+        private static Vector3 CAMPFIRE_ROTATION = new Vector3(95f, 0f, 38f);
 
         private static Dictionary<string, Action[]> actionsMap = new Dictionary<string, Action[]>
         {
@@ -70,8 +72,8 @@ namespace NomaiGrandPrix
             );
             var campfire = GameObject.Instantiate(campfirePrefab.gameObject, timeLoopRing.transform);
 
-            campfire.transform.localPosition = new Vector3(18, 0.18f, -21);
-            campfire.transform.Rotate(new Vector3(95, 0, 38), Space.Self);
+            campfire.transform.localPosition = CAMPFIRE_SPAWN_POSITION;
+            campfire.transform.Rotate(CAMPFIRE_ROTATION, Space.Self);
 
             var interactReceiver = campfire.GetComponentInChildren<InteractReceiver>();
             interactReceiver.Start();

--- a/NomaiGrandPrix/SpawnPoints.tsv
+++ b/NomaiGrandPrix/SpawnPoints.tsv
@@ -1,7 +1,7 @@
 Full Name	Display Name	Area	Dream Zone	Enable Spawn	Enable Goal	TH Village	Note
 Spawn	Sun Station Inside	SunStation	FALSE	TRUE	TRUE	FALSE	
 ShipSpawn	Sun Station Outside	SunStation	FALSE	FALSE	FALSE	TRUE	
-Spawn_TimeLoopDevice	Ash Twin Project	AshTwin	FALSE	FALSE	TRUE	FALSE	Trapped if used as spawn
+Spawn_TimeLoopDevice	Ash Twin Project	AshTwin	FALSE	TRUE	TRUE	FALSE	
 Spawn_SunTower	Warp Tower (Sun Station)	AshTwin	FALSE	TRUE	TRUE	FALSE	
 Spawn_TowerTwin	Warp Tower (Twins)	AshTwin	FALSE	TRUE	TRUE	FALSE	
 Spawn_FossilSite	Anglerfish Fossil	EmberTwin	FALSE	TRUE	TRUE	FALSE	


### PR DESCRIPTION
This change does the following:
- Reenables Ash Twin Project as a spawn point
- Creates a functioning campfire in Ash Twin Project (roughly halfway between the warp receiver and first Nomai Computer, so it is visible when you warp)
- Enables the warp receiver in Ash Twin Project so it will teleport you back to the appropriate tower warp
- Modifies the behavior of the tower warp, so that when the player warps there, they will be crushed to death if the world time is less than 6:55 due to being warped under the sand. This gives the player roughly a 5 second period where they can teleport into the sand without dying.

Testing:
- Verified that the campfire works for roasting marshmallows and sleeping
- Verified that the player is properly detached after exiting marshmallow/sleep mod
- Verified that the campfire works multiple times
- Verified that the teleporter has the appropriate glow effect when you leave it
- Verified that the teleporter teleports you to the appropriate tower warp
- Verified that you die by crushing if you use the teleporter too early
- Verified that you can survive in the sand for about 5 seconds if you teleport at just the right time
- Verified that teleporting well after the 6:55 mark works as expected
- Verified that you can teleport back into Ash Twin from the tower warp and back out to it again