### PR TITLE
Show spawn/goal strings below timer on completion

### DIFF
--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -134,8 +134,11 @@ namespace NomaiGrandPrix
                 SpeedrunState.EndTime == DateTime.MinValue
                     ? DateTime.Now - SpeedrunState.StartTime
                     : SpeedrunState.EndTime - SpeedrunState.StartTime;
+
+            var color = SpeedrunState.IsComplete() ? Constants.OW_SELECTED_COLOR : Constants.OW_ORANGE_COLOR;
             var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
-            _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(Constants.OW_ORANGE_COLOR)}>{elapsedStr}</color>");
+
+            _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{elapsedStr}</color>");
         }
 
         public override void Configure(IModConfig config)

--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -185,18 +185,18 @@ namespace NomaiGrandPrix
 
         private void UpdateTimer()
         {
-            var elapsed =
-                SpeedrunState.EndTime == DateTime.MinValue
-                    ? DateTime.Now - SpeedrunState.StartTime
-                    : SpeedrunState.EndTime - SpeedrunState.StartTime;
+            (var elapsed, var color) =
+                SpeedrunState.IsComplete()
+                    ? (SpeedrunState.EndTime - SpeedrunState.StartTime, Constants.OW_SELECTED_COLOR)
+                    : (DateTime.Now - SpeedrunState.StartTime, Constants.OW_ORANGE_COLOR);
 
-            var color = SpeedrunState.IsComplete() ? Constants.OW_SELECTED_COLOR : Constants.OW_ORANGE_COLOR;
+            var colorStr = ColorUtility.ToHtmlStringRGB(color);
 
             var pathDescription = $"{SpeedrunState.SpawnPoint?.displayName} - {SpeedrunState.GoalPoint?.displayName}";
-            _spawnGoalPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{pathDescription}</color>");
+            _spawnGoalPrompt.SetText($"<color=#{colorStr}>{pathDescription}</color>");
 
             var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
-            _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{elapsedStr}</color>");
+            _timerPrompt.SetText($"<color=#{colorStr}>{elapsedStr}</color>");
         }
 
         private void HandleBasicWarp(PlayerSpawner spawner, SpawnPoint[] spawnPoints)

--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -130,15 +130,7 @@ namespace NomaiGrandPrix
                 }
             }
 
-            var elapsed =
-                SpeedrunState.EndTime == DateTime.MinValue
-                    ? DateTime.Now - SpeedrunState.StartTime
-                    : SpeedrunState.EndTime - SpeedrunState.StartTime;
-
-            var color = SpeedrunState.IsComplete() ? Constants.OW_SELECTED_COLOR : Constants.OW_ORANGE_COLOR;
-            var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
-
-            _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{elapsedStr}</color>");
+            UpdateTimer();
         }
 
         public override void Configure(IModConfig config)
@@ -174,6 +166,19 @@ namespace NomaiGrandPrix
             );
             var screenPromptElement = screenPromptElementObj.GetComponent<ScreenPromptElement>();
             screenPromptList.AddScreenPrompt(screenPromptElement);
+        }
+
+        private void UpdateTimer()
+        {
+            var elapsed =
+                SpeedrunState.EndTime == DateTime.MinValue
+                    ? DateTime.Now - SpeedrunState.StartTime
+                    : SpeedrunState.EndTime - SpeedrunState.StartTime;
+
+            var color = SpeedrunState.IsComplete() ? Constants.OW_SELECTED_COLOR : Constants.OW_ORANGE_COLOR;
+            var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
+
+            _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{elapsedStr}</color>");
         }
 
         private void HandleBasicWarp(PlayerSpawner spawner, SpawnPoint[] spawnPoints)

--- a/NomaiGrandPrix/NomaiGrandPrix.cs
+++ b/NomaiGrandPrix/NomaiGrandPrix.cs
@@ -20,6 +20,7 @@ namespace NomaiGrandPrix
         private IModButton _speedrunButton;
         private IModButton _resetRunButton;
         private ScreenPrompt _timerPrompt;
+        private ScreenPrompt _spawnGoalPrompt;
         private Mesh _marshmallowMesh;
         private Material _marshmallowMaterial;
         private CanvasMarker _canvasMarker;
@@ -155,17 +156,31 @@ namespace NomaiGrandPrix
             var screenPromptListObj = GameObject.Find("ScreenPromptListBottomLeft");
             var screenPromptList = screenPromptListObj.GetComponent<ScreenPromptList>();
 
-            _timerPrompt = new ScreenPrompt("");
             var font = GetFontByName(Constants.OW_MENU_FONT_NAME);
-            var screenPromptElementObj = ScreenPromptElement.CreateNewScreenPrompt(
+
+            _timerPrompt = new ScreenPrompt("");
+            var timerScreenPromptElementObj = ScreenPromptElement.CreateNewScreenPrompt(
                 _timerPrompt,
                 20,
                 font,
                 screenPromptListObj.transform,
                 TextAnchor.LowerLeft
             );
-            var screenPromptElement = screenPromptElementObj.GetComponent<ScreenPromptElement>();
-            screenPromptList.AddScreenPrompt(screenPromptElement);
+
+            _spawnGoalPrompt = new ScreenPrompt("");
+            var spawnGoalScreenPromptElementObj = ScreenPromptElement.CreateNewScreenPrompt(
+                _spawnGoalPrompt,
+                12,
+                font,
+                screenPromptListObj.transform,
+                TextAnchor.LowerLeft
+            );
+
+            var spawnGoalScreenPromptElement = spawnGoalScreenPromptElementObj.GetComponent<ScreenPromptElement>();
+            var timerScreenPromptElement = timerScreenPromptElementObj.GetComponent<ScreenPromptElement>();
+
+            screenPromptList.AddScreenPrompt(spawnGoalScreenPromptElement);
+            screenPromptList.AddScreenPrompt(timerScreenPromptElement);
         }
 
         private void UpdateTimer()
@@ -176,8 +191,11 @@ namespace NomaiGrandPrix
                     : SpeedrunState.EndTime - SpeedrunState.StartTime;
 
             var color = SpeedrunState.IsComplete() ? Constants.OW_SELECTED_COLOR : Constants.OW_ORANGE_COLOR;
-            var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
 
+            var pathDescription = $"{SpeedrunState.SpawnPoint?.displayName} - {SpeedrunState.GoalPoint?.displayName}";
+            _spawnGoalPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{pathDescription}</color>");
+
+            var elapsedStr = string.Format("{0:D2}:{1:D2}.{2:D3}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds);
             _timerPrompt.SetText($"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{elapsedStr}</color>");
         }
 

--- a/NomaiGrandPrix/SpeedrunState.cs
+++ b/NomaiGrandPrix/SpeedrunState.cs
@@ -29,5 +29,7 @@ namespace NomaiGrandPrix
         {
             // Default constructor required when using field initializers
         }
+
+        public bool IsComplete() => EndTime > DateTime.MinValue;
     }
 }


### PR DESCRIPTION
Fixes #117

This PR updates the speedrun timer such that on the player reaching their goal:
- The spawn and goal locations are visible below the timer
- The timer and locations are rendered as white

This works, although for some reason the text disappears when the player switches from controller inputs to keyboard inputs. I'm not yet sure why that's happening after the run is over, but not during the run. Nothing shows up in the logs either :/